### PR TITLE
Set object in objectmode before building

### DIFF
--- a/g3d_exporter/export_operator.py
+++ b/g3d_exporter/export_operator.py
@@ -244,6 +244,7 @@ class BaseG3dExportOperator(ExportHelper):
             opt = self._build_options()
 
             builder.b_log = self.report
+            bpy.ops.object.mode_set(mode='OBJECT')
             model = builder.build(opt)
 
             out = Path(self.filepath)


### PR DESCRIPTION
Otherwise i get error: ``Mesh 'Mesh' is in editmode``

```
Error: Python: Traceback (most recent call last):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/export_operator.py", line 248, in execute
    model = builder.build(opt)
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 55, in build
    return G3Builder(opt).build()
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 899, in build
    for node in self._process_layer_collection(root):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 914, in _process_layer_collection
    for node in self._process_layer_collection(lc):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 910, in _process_layer_collection
    for node in self._process_collection(layer_col.collection, False, self.opt.selected_only, ""):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 930, in _process_collection
    for node in self._process_object(obj, collection, selected_only, id_prefix):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 955, in _process_object
    (eval_obj, eval_mesh) = evaluate(obj, self.opt.apply_modifiers)
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 1162, in evaluate
    triangulate(obj_eval.data)
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 1144, in triangulate
    bm.to_mesh(mesh)
ValueError: to_mesh(): Mesh 'Mesh' is in editmode
Location: /usr/share/blender/3.2/scripts/modules/bpy/ops.py:115
Traceback (most recent call last):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/export_operator.py", line 248, in execute
    model = builder.build(opt)
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 55, in build
    return G3Builder(opt).build()
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 899, in build
    for node in self._process_layer_collection(root):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 914, in _process_layer_collection
    for node in self._process_layer_collection(lc):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 910, in _process_layer_collection
    for node in self._process_collection(layer_col.collection, False, self.opt.selected_only, ""):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 930, in _process_collection
    for node in self._process_object(obj, collection, selected_only, id_prefix):
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 955, in _process_object
    (eval_obj, eval_mesh) = evaluate(obj, self.opt.apply_modifiers)
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 1162, in evaluate
    triangulate(obj_eval.data)
  File "/home/ryuukk/.config/blender/3.2/scripts/addons/g3d_exporter/builder.py", line 1144, in triangulate
    bm.to_mesh(mesh)
``` 