### PR TITLE
Fix (bi)tangents not being exported correctly

### DIFF
--- a/g3d_exporter/builder.py
+++ b/g3d_exporter/builder.py
@@ -616,6 +616,9 @@ class MeshNodeDataBuilder(object):
         if self.opt.use_binormal:
             meta.attributes.append(BiTangentAttributeBuilder())
 
+        if self.opt.use_tangent or self.opt.use_binormal:
+            mesh.calc_tangents()
+
         color_layers = mesh.vertex_colors
         if self.opt.use_color and len(color_layers) > 0:
             if self.opt.packed_color:


### PR DESCRIPTION
Without calling `bpy.types.Mesh.calc_tangents()` my models were being exported with tangent & bitangent fields all set to 0.0.

I'm not an expert at Blender scripting so if there's a more appropriate place to put this line let me know, but I found it needs to go before the attribute builders are constructed or UV coordinates get trashed.